### PR TITLE
Add coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
+        env:
+          COVERAGE: "1"
+
+      - name: Code Climate
+        if: matrix.ruby_version == '3.0'
+        uses: paambaati/codeclimate-action@v2.7.5
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
   release:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .rubocop-*
-Gemfile.lock
 .ruby-version
+Gemfile.lock
+coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'solargraph'
 
 gem 'rake'
 gem 'rubocop', '0.91.1'
+gem 'simplecov', '~> 0.21'
+gem 'simplecov-console', '~> 0.9'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+if %w[yes true 1].include?(ENV['COVERAGE'])
+  require 'simplecov'
+  require 'simplecov-console'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::Console
+    ]
+  )
+
+  SimpleCov.start 'test_frameworks'
+end
+
 SPEC_ROOT = __dir__
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'apia'


### PR DESCRIPTION
For the CodeClimate setup to work, someone with admin perms on this repo needs to configure it in CodeClimate, and add the `CC_TEST_REPORTER_ID` secret.