### PR TITLE
Decorate generated hashes

### DIFF
--- a/lib/apia/field_set.rb
+++ b/lib/apia/field_set.rb
@@ -5,6 +5,7 @@ require 'apia/scalar'
 require 'apia/object'
 require 'apia/enum'
 require 'apia/field_spec'
+require 'apia/generated_hash'
 
 module Apia
   class FieldSet < Hash
@@ -35,10 +36,12 @@ module Apia
     #
     # @param source [Object, Hash]
     # @param request [Apia::Request]
+    # @param object [Apia::Object] the object that this fieldset belongs to
     # @param only [Array]
     # @return [Hash]
-    def generate_hash(source, request: nil, path: [])
-      each_with_object({}) do |(_, field), hash|
+    def generate_hash(source, request: nil, path: [], object: nil)
+      new_hash = GeneratedHash.enabled? ? GeneratedHash.new(object, source, path: path) : {}
+      each_with_object(new_hash) do |(_, field), hash|
         next unless field.include?(source, request)
 
         field_path = path + [field]

--- a/lib/apia/generated_hash.rb
+++ b/lib/apia/generated_hash.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Apia
+  class GeneratedHash < Hash
+
+    attr_reader :object
+    attr_reader :source
+    attr_reader :path
+
+    def initialize(object, source, path: nil)
+      super()
+      @object = object
+      @source = source
+      @path = path
+    end
+
+    class << self
+
+      def enabled?
+        @enabled == true
+      end
+
+      def enable
+        @enabled = true
+      end
+
+    end
+
+  end
+end

--- a/lib/apia/object.rb
+++ b/lib/apia/object.rb
@@ -49,7 +49,7 @@ module Apia
     # @param request [Apia::Request] the associated request
     # @return [Hash]
     def hash(request: nil, path: [])
-      self.class.definition.fields.generate_hash(@value, request: request, path: path)
+      self.class.definition.fields.generate_hash(@value, object: self, request: request, path: path)
     end
 
     # Should this type be included in any output?

--- a/spec/specs/apia/field_set_spec.rb
+++ b/spec/specs/apia/field_set_spec.rb
@@ -248,5 +248,19 @@ describe Apia::FieldSet do
         }
       })
     end
+
+    context 'when GeneratedHash is enabled' do
+      before do
+        allow(Apia::GeneratedHash).to receive(:enabled?).and_return(true)
+      end
+
+      it 'sets the source on the hash to the fieldset' do
+        example = '12345'
+        hash = field_set.generate_hash({}, object: example)
+        expect(hash).to be_a Apia::GeneratedHash
+        expect(hash.object).to eq example
+        expect(hash.source).to eq({})
+      end
+    end
   end
 end

--- a/spec/specs/apia/object_spec.rb
+++ b/spec/specs/apia/object_spec.rb
@@ -174,5 +174,25 @@ describe Apia::Object do
       hash = instance.hash
       expect(hash[:status]).to eq 'active'
     end
+
+    context 'when HashWithObject is enabled' do
+      before do
+        allow(Apia::GeneratedHash).to receive(:enabled?).and_return(true)
+      end
+
+      it 'passes the object to the hash for the source' do
+        type = Apia::Object.create('ExampleType') do
+          field :id, type: :string
+          field :number, type: :integer
+        end
+        source = { id: 'hello', number: 1234 }
+        type_instance = type.new(source)
+        hash = type_instance.hash
+        expect(hash).to be_a(Apia::GeneratedHash)
+        expect(hash.object).to be_a type
+        expect(hash.object).to eq type_instance
+        expect(hash.source).to eq source
+      end
+    end
   end
 end


### PR DESCRIPTION
This can help with testing generated output from APIs. It requires enabling if you want to use this using `Apia::GeneratedHash.enable`.