### PR TITLE
Allow authenticators to set CORS headers

### DIFF
--- a/apia.gemspec
+++ b/apia.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative './lib/apia/version'
+require_relative 'lib/apia/version'
 
 Gem::Specification.new do |s|
   s.name          = 'apia'

--- a/examples/core_api/main_authenticator.rb
+++ b/examples/core_api/main_authenticator.rb
@@ -14,6 +14,16 @@ module CoreAPI
     end
 
     def call
+      # Define a list of cors methods that are permitted for the request.
+      cors.methods = %w[GET POST PUT PATCH DELETE OPTIONS]
+
+      # Define a list of cors headers that are permitted for the request.
+      cors.headers = %w[X-Custom-Header]
+
+      # Define a the hostname to allow for CORS requests.
+      cors.origin = '*' # or 'example.com'
+      cors.origin = 'krystal.uk'
+
       given_token = request.headers['authorization']&.sub(/\ABearer /, '')
       case given_token
       when 'example'

--- a/lib/apia/cors.rb
+++ b/lib/apia/cors.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Apia
+  class CORS
+
+    attr_accessor :methods
+    attr_accessor :headers
+    attr_accessor :origin
+
+    def initialize
+      @origin = '*'
+      @methods = '*'
+      @headers = []
+    end
+
+    def to_headers
+      return {} if @origin.nil?
+
+      headers = {}
+      headers['Access-Control-Allow-Origin'] = @origin
+
+      if @methods.is_a?(String)
+        headers['Access-Control-Allow-Methods'] = @methods
+      elsif @methods.is_a?(Array) && @methods.any?
+        headers['Access-Control-Allow-Methods'] = @methods.map(&:upcase).join(', ')
+      end
+
+      if @headers.is_a?(String)
+        headers['Access-Control-Allow-Headers'] = @headers
+      elsif @headers.is_a?(Array) && @headers.any?
+        headers['Access-Control-Allow-Headers'] = @headers.join(', ')
+      end
+
+      headers
+    end
+
+  end
+end

--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -65,9 +65,7 @@ module Apia
 
       api_path = Regexp.last_match(1)
 
-      triplet = handle_request(env, api_path)
-      add_cors_headers(env, triplet)
-      triplet
+      handle_request(env, api_path)
     end
 
     private
@@ -76,10 +74,6 @@ module Apia
       request = nil
       request_method = env['REQUEST_METHOD'].upcase
       notify_hash = { api: api, env: env, path: api_path, method: request_method }
-
-      if request_method.upcase == 'OPTIONS'
-        return [204, {}, ['']]
-      end
 
       Apia::Notifications.notify(:request_start, notify_hash)
 
@@ -153,21 +147,6 @@ module Apia
         },
         status: 500
       )
-    end
-
-    # Add cross origin headers to the response triplet
-    #
-    # @param env [Hash]
-    # @param triplet [Array]
-    # @return [void]
-    def add_cors_headers(env, triplet)
-      triplet[1]['Access-Control-Allow-Origin'] = '*'
-      triplet[1]['Access-Control-Allow-Methods'] = '*'
-      if env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
-        triplet[1]['Access-Control-Allow-Headers'] = env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']
-      end
-
-      true
     end
 
     class << self

--- a/lib/apia/request_environment.rb
+++ b/lib/apia/request_environment.rb
@@ -2,6 +2,7 @@
 
 require 'apia/environment_error_handling'
 require 'apia/errors/invalid_helper_error'
+require 'apia/cors'
 
 module Apia
   class RequestEnvironment
@@ -72,6 +73,10 @@ module Apia
         pagination_info[:total_pages] = paginated.total_pages
       end
       @response.add_field :pagination, pagination_info
+    end
+
+    def cors
+      @cors ||= CORS.new
     end
 
     private

--- a/spec/specs/apia/cors_spec.rb
+++ b/spec/specs/apia/cors_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apia/cors'
+
+describe Apia::CORS do
+  describe '#to_headers' do
+    subject(:cors) { described_class.new }
+
+    context 'with the details' do
+      it 'returns a wildcard origin and methods' do
+        expect(cors.to_headers).to eq({ 'Access-Control-Allow-Origin' => '*',
+                                        'Access-Control-Allow-Methods' => '*' })
+      end
+    end
+
+    context 'when origin is set to nil' do
+      it 'returns an empty array' do
+        cors.origin = nil
+        expect(cors.to_headers).to eq({})
+      end
+    end
+
+    context 'when origin is set to a hostname' do
+      before do
+        cors.origin = 'example.com'
+      end
+
+      it 'includes the Access-Control-Allow-Origin header' do
+        expect(cors.to_headers).to eq({
+          'Access-Control-Allow-Origin' => 'example.com',
+          'Access-Control-Allow-Methods' => '*'
+        })
+      end
+
+      context 'when methods have been provided' do
+        it 'includes the Access-Control-Allow-Methods header' do
+          cors.methods = %w[GET POST]
+          expect(cors.to_headers).to eq({
+            'Access-Control-Allow-Origin' => 'example.com',
+            'Access-Control-Allow-Methods' => 'GET, POST'
+          })
+        end
+
+        it 'upcases any methods provided' do
+          cors.methods = %w[get post]
+          expect(cors.to_headers).to eq({
+            'Access-Control-Allow-Origin' => 'example.com',
+            'Access-Control-Allow-Methods' => 'GET, POST'
+          })
+        end
+      end
+
+      context 'when headers have been provided' do
+        it 'includes the Access-Control-Allow-Headers header' do
+          cors.headers = %w[X-Custom Content-Type]
+          expect(cors.to_headers).to eq({
+            'Access-Control-Allow-Origin' => 'example.com',
+            'Access-Control-Allow-Methods' => '*',
+            'Access-Control-Allow-Headers' => 'X-Custom, Content-Type'
+          })
+        end
+      end
+
+      context 'when methods and headers have been provided' do
+        it 'includes the Access-Control-Allow-Methods and Access-Control-Allow-Headers headers' do
+          cors.methods = %w[GET POST]
+          cors.headers = %w[X-Custom Content-Type]
+          expect(cors.to_headers).to eq({
+            'Access-Control-Allow-Origin' => 'example.com',
+            'Access-Control-Allow-Methods' => 'GET, POST',
+            'Access-Control-Allow-Headers' => 'X-Custom, Content-Type'
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/specs/apia/rack_spec.rb
+++ b/spec/specs/apia/rack_spec.rb
@@ -94,42 +94,6 @@ describe Apia::Rack do
       end
     end
 
-    context 'cors' do
-      it 'should return no content with CORS headers in response to all options requests' do
-        api = Apia::API.create('MyAPI')
-        rack = described_class.new(app, api, 'api/v1')
-        env = Rack::MockRequest.env_for('/api/v1/test', method: 'OPTIONS')
-        result = rack.call(env)
-        expect(result).to be_a Array
-        expect(result[0]).to eq 204
-        expect(result[2][0]).to be_empty
-        expect(result[1]['Access-Control-Allow-Origin']).to eq '*'
-        expect(result[1]['Access-Control-Allow-Methods']).to eq '*'
-      end
-
-      it 'should include cors headers on successful requests' do
-        controller = Apia::Controller.create('Controller') do
-          endpoint :test do
-            action do
-              response.add_header 'x-demo', 'hello'
-            end
-          end
-        end
-        api = Apia::API.create('MyAPI') do
-          routes do
-            get 'test', controller: controller, endpoint: :test
-          end
-        end
-        rack = described_class.new(app, api, 'api/v1')
-        env = Rack::MockRequest.env_for('/api/v1/test')
-        result = rack.call(env)
-        expect(result).to be_a Array
-        expect(result[0]).to eq 200
-        expect(result[1]['Access-Control-Allow-Origin']).to eq '*'
-        expect(result[1]['Access-Control-Allow-Methods']).to eq '*'
-      end
-    end
-
     it 'should allow requests with matching hostnames through' do
       controller = Apia::Controller.create('Controller') do
         endpoint :test do

--- a/spec/specs/apia/request_environment_spec.rb
+++ b/spec/specs/apia/request_environment_spec.rb
@@ -264,4 +264,12 @@ describe Apia::RequestEnvironment do
       expect(environment.response.fields[:widgets].last).to eq 's50'
     end
   end
+
+  context '#cors' do
+    subject(:environment) { setup_api }
+
+    it 'returns a CORS instance' do
+      expect(environment.cors).to be_a Apia::CORS
+    end
+  end
 end


### PR DESCRIPTION
Apia currently always sets very permissive CORS headers because it has never been designed to work with any API which is authenticated on the presence of a cookie and thus CORS has not been issue as authentication should always be provided along with the request. 

However, to allow for greater flexibility, this PR introduces the ability for authenticators to set CORS headers on responses without them being overridden later by the default.

The original default remains permissive (and by that I mean the `'Access-Control-Allow-Origin` header will return `*` and the `Access-Control-Allow-Methods` will also return `*`.

## Usage

To use this, you simply need to define appropriate values within your authenticator.

```ruby
class MyAuthenticator < Apia::Authenticator

  def call
    cors.origin = "example.com"
    cors.methods = ["GET", "POST"]
    cors.headers = ["X-Custom"]

    # Do other authentication actions as appropriate.
  end
end
```

The `origin` can only contain a single hostname so if you support multiple hosts, you'll need to provide logic to return the appropriate value.

```ruby
class MyAuthenticator < Apia::Authenticator
  

  ALLOWED_ORIGINS = ['example.com', 'example.org']

  def call
    if ALLOWED_ORIGINS.include?(request.host)
      # If the origin is permitted, return the current host name
      # as the origin
      cors.origin = request.host
    else
      # Ensure origin is set to nil otherwise the default value of *
      # will be used allowing all requests.
      cors.origin = nil
    end

    # Other authentication as appropriate...
  end
end
```