### PR TITLE
feat: support any response type

### DIFF
--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -162,6 +162,26 @@ module Apia
         response_triplet(body, content_type: Apia::Response::PLAIN, status: status, headers: headers)
       end
 
+      # Return an HTML triplet for the given body.
+      #
+      # @param body [String]
+      # @param status [Integer]
+      # @param headers [Hash]
+      # @return [Array]
+      def html_triplet(body, status: 200, headers: {})
+        response_triplet(body, content_type: Apia::Response::HTML, status: status, headers: headers)
+      end
+
+      # Return a Turbo Stream triplet for the given body.
+      #
+      # @param body [String]
+      # @param status [Integer]
+      # @param headers [Hash]
+      # @return [Array]
+      def turbo_stream_triplet(body, status: 200, headers: {})
+        response_triplet(body, content_type: Apia::Response::TURBO_STREAM, status: status, headers: headers)
+      end
+
       # Return a JSON-ready triplet for the given body.
       #
       # @param body [Hash, Array]

--- a/lib/apia/response.rb
+++ b/lib/apia/response.rb
@@ -8,7 +8,9 @@ module Apia
 
     TYPES = [
       JSON = 'application/json',
-      PLAIN = 'text/plain'
+      PLAIN = 'text/plain',
+      HTML = 'text/html',
+      TURBO_STREAM = 'text/vnd.turbo-stream.html'
     ].freeze
 
     attr_accessor :status
@@ -72,10 +74,10 @@ module Apia
     def rack_triplet
       # Errors will always be sent as a hash intended for JSON encoding,
       # even if the endpoint specifies a plain text response, so only
-      # send a pain response if the type is plaintext _and_ the body is
-      # a string
-      if @type == PLAIN && body.is_a?(String)
-        Rack.plain_triplet(body, headers: headers, status: status)
+      # send a plain response if the type is plaintext _and_ the body is
+      # a string. Same logic applies to HTML and Turbo Stream responses.
+      if (@type == PLAIN || @type == HTML || @type == TURBO_STREAM) && body.is_a?(String)
+        Rack.response_triplet(body, content_type: @type, status: status, headers: headers)
       else
         Rack.json_triplet(body, headers: headers, status: status)
       end


### PR DESCRIPTION
Previously you could only respond with `application/json` or `text/plain`. This now allows any response types. It maintains forcing a JSON response when the body is not a string, as error messages are sent as a hash.